### PR TITLE
update flink 1_18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.12.19"
 
-val flinkVersion = "1.17.0"
-
+val flinkVersion = "1.18.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -11,5 +11,6 @@ lazy val root = (project in file("."))
       "org.apache.flink" % "flink-runtime-web" % flinkVersion,
       "org.apache.flink" %% "flink-scala" % flinkVersion,
       "org.apache.flink" %% "flink-streaming-scala" % flinkVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.3")
+      "ch.qos.logback" % "logback-classic" % "1.2.3"),
+    Compile / run / fork := true
   )


### PR DESCRIPTION
After a minor update of the Flink application from Flink 1.17 to 1.18, it fails to run from sbt.
But, it can be run with the following run/debug in IntelliJ.

```
sbt version = 1.9.9
scala version = 2.12.19
flink version = 1.18.0
```


This error does not occur in Flink 1.17, but only in Flink 1.18 and above.

This may be due to the fact that all Scala APIs are deprecated in Flink 1.18.

https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support

## Run/debug configuration: Application

[Run/debug configuration: Application﻿](https://www.jetbrains.com/help/idea/run-debug-configuration-java-application.html)

> This run/debug configuration is the most common template for Java, which corresponds to compiling your program with javac and then running it with java.


<img width="1041" alt="スクリーンショット 2024-06-02 15 27 20" src="https://github.com/taketora26/flink-app/assets/21272619/aa4aa832-a7ab-4beb-8327-769cb0a3734c">


### result


<details><summary>full log</summary>

```
/Users/taketo.ikeda/.sdkman/candidates/java/17.0.9-amzn/bin/java -javaagent:/Users/taketo.ikeda/Applications/IntelliJ IDEA Ultimate.app/Contents/lib/idea_rt.jar=56943:/Users/taketo.ikeda/Applications/IntelliJ IDEA Ultimate.app/Contents/bin -Dfile.encoding=UTF-8 -classpath /Users/taketo.ikeda/Work/study/flink-app/target/scala-2.12/classes:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/esotericsoftware/kryo/kryo/2.24.0/kryo-2.24.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/esotericsoftware/minlog/minlog/1.2/minlog-1.2.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/twitter/chill-java/0.7.6/chill-java-0.7.6.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/twitter/chill_2.12/0.7.6/chill_2.12-0.7.6.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-annotations/1.18.0/flink-annotations-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-clients/1.18.0/flink-clients-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-core/1.18.0/flink-core-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-file-sink-common/1.18.0/flink-file-sink-common-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-hadoop-fs/1.18.0/flink-hadoop-fs-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-java/1.18.0/flink-java-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-metrics-core/1.18.0/flink-metrics-core-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-optimizer/1.18.0/flink-optimizer-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-queryable-state-client-java/1.18.0/flink-queryable-state-client-java-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-rpc-akka-loader/1.18.0/flink-rpc-akka-loader-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-rpc-core/1.18.0/flink-rpc-core-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime-web/1.18.0/flink-runtime-web-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime/1.18.0/flink-runtime-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-scala_2.12/1.18.0/flink-scala_2.12-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-asm-9/9.5-17.0/flink-shaded-asm-9-9.5-17.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-guava/31.1-jre-17.0/flink-shaded-guava-31.1-jre-17.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-jackson/2.14.2-17.0/flink-shaded-jackson-2.14.2-17.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-netty/4.1.91.Final-17.0/flink-shaded-netty-4.1.91.Final-17.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-zookeeper-3/3.7.1-17.0/flink-shaded-zookeeper-3-3.7.1-17.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-streaming-java/1.18.0/flink-streaming-java-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-streaming-scala_2.12/1.18.0/flink-streaming-scala_2.12-1.18.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/javassist/javassist/3.24.0-GA/javassist-3.24.0-GA.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.1/objenesis-2.1.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/2.2.0/scala-xml_2.12-2.2.0.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.19/scala-compiler-2.12.19.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.19/scala-library-2.12.19.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.19/scala-reflect-2.12.19.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar:/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.10.4/snappy-java-1.1.10.4.jar Main
[2024-06-02 16:08:08,467] [INFO] [org.apache.flink.api.java.utils.PlanGenerator] [main] [] - The job has 0 registered types and 0 default Kryo serializers
[2024-06-02 16:08:08,618] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.cpu.cores required for local execution is not set, setting it to the maximal possible value.
[2024-06-02 16:08:08,618] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.memory.task.heap.size required for local execution is not set, setting it to the maximal possible value.
[2024-06-02 16:08:08,618] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.memory.task.off-heap.size required for local execution is not set, setting it to the maximal possible value.
[2024-06-02 16:08:08,619] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.memory.network.min required for local execution is not set, setting it to its default value 64 mb.
[2024-06-02 16:08:08,619] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.memory.network.max required for local execution is not set, setting it to its default value 64 mb.
[2024-06-02 16:08:08,619] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils] [main] [] - The configuration option taskmanager.memory.managed.size required for local execution is not set, setting it to its default value 128 mb.
[2024-06-02 16:08:08,622] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [main] [] - Starting Flink Mini Cluster
[2024-06-02 16:08:08,840] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [main] [] - Starting Metrics Registry
[2024-06-02 16:08:08,876] [INFO] [org.apache.flink.runtime.metrics.MetricRegistryImpl] [main] [] - No metrics reporter configured, no metrics will be exposed/reported.
[2024-06-02 16:08:08,876] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [main] [] - Starting RPC Service(s)
[2024-06-02 16:08:08,886] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcServiceUtils] [main] [] - Trying to start local actor system
[2024-06-02 16:08:09,294] [INFO] [org.apache.pekko.event.slf4j.Slf4jLogger] [flink-pekko.actor.default-dispatcher-4] [] - Slf4jLogger started
[2024-06-02 16:08:09,375] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcServiceUtils] [main] [] - Actor system started at pekko://flink
[2024-06-02 16:08:09,385] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcServiceUtils] [main] [] - Trying to start local actor system
[2024-06-02 16:08:09,393] [INFO] [org.apache.pekko.event.slf4j.Slf4jLogger] [flink-metrics-4] [] - Slf4jLogger started
[2024-06-02 16:08:09,400] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcServiceUtils] [main] [] - Actor system started at pekko://flink-metrics
[2024-06-02 16:08:09,407] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [main] [] - Starting RPC endpoint for org.apache.flink.runtime.metrics.dump.MetricQueryService at pekko://flink-metrics/user/rpc/MetricQueryService .
[2024-06-02 16:08:09,482] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Loading delegation token providers
[2024-06-02 16:08:09,484] [INFO] [org.apache.flink.runtime.security.token.hadoop.HadoopFSDelegationTokenProvider] [main] [] - Hadoop FS is not available (not packaged with this application): NoClassDefFoundError : "org/apache/hadoop/conf/Configuration".
[2024-06-02 16:08:09,484] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Delegation token provider hadoopfs loaded and initialized
[2024-06-02 16:08:09,490] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Delegation token provider hbase loaded and initialized
[2024-06-02 16:08:09,490] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Delegation token providers loaded successfully
[2024-06-02 16:08:09,490] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Loading delegation token receivers
[2024-06-02 16:08:09,491] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receiver hadoopfs loaded and initialized
[2024-06-02 16:08:09,492] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receiver hbase loaded and initialized
[2024-06-02 16:08:09,492] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receivers loaded successfully
[2024-06-02 16:08:09,492] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Checking provider and receiver instances consistency
[2024-06-02 16:08:09,492] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Provider and receiver instances are consistent
[2024-06-02 16:08:09,492] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Obtaining delegation tokens
[2024-06-02 16:08:09,493] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - Delegation tokens obtained successfully
[2024-06-02 16:08:09,493] [WARN] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [main] [] - No tokens obtained so skipping notifications
[2024-06-02 16:08:09,493] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Loading delegation token receivers
[2024-06-02 16:08:09,494] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receiver hadoopfs loaded and initialized
[2024-06-02 16:08:09,494] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receiver hbase loaded and initialized
[2024-06-02 16:08:09,494] [INFO] [org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository] [main] [] - Delegation token receivers loaded successfully
[2024-06-02 16:08:09,501] [INFO] [org.apache.flink.runtime.blob.BlobServer] [main] [] - Created BLOB server storage directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/minicluster_e28a0c1be6ad9e90586d7434bcf2d1e4/blobStorage
[2024-06-02 16:08:09,506] [INFO] [org.apache.flink.runtime.blob.BlobServer] [main] [] - Started BLOB server at 0.0.0.0:56947 - max concurrent requests: 50 - max backlog: 1000
[2024-06-02 16:08:09,517] [INFO] [org.apache.flink.runtime.blob.PermanentBlobCache] [main] [] - Created BLOB cache storage directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/minicluster_e28a0c1be6ad9e90586d7434bcf2d1e4/blobStorage
[2024-06-02 16:08:09,520] [INFO] [org.apache.flink.runtime.blob.TransientBlobCache] [main] [] - Created BLOB cache storage directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/minicluster_e28a0c1be6ad9e90586d7434bcf2d1e4/blobStorage
[2024-06-02 16:08:09,522] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [main] [] - Starting 1 TaskManager(s)
[2024-06-02 16:08:09,526] [INFO] [org.apache.flink.runtime.taskexecutor.TaskManagerRunner] [main] [] - Starting TaskManager with ResourceID: 47893016-4df0-472e-bd91-8e8cc5cd9e5d
[2024-06-02 16:08:09,539] [INFO] [org.apache.flink.runtime.taskexecutor.TaskManagerServices] [main] [] - Temporary file directory '/var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T': total 931 GB, usable 728 GB (78.20% usable)
[2024-06-02 16:08:09,542] [INFO] [org.apache.flink.runtime.io.disk.iomanager.IOManager] [main] [] - Created a new FileChannelManager for spilling of task related data to disk (joins, sorting, ...). Used directories:
	/var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-io-211b9d60-f45d-4af3-9d82-0d92cd5e8238
[2024-06-02 16:08:09,547] [INFO] [org.apache.flink.runtime.io.network.NettyShuffleServiceFactory] [main] [] - Created a new FileChannelManager for storing result partitions of BLOCKING shuffles. Used directories:
	/var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-netty-shuffle-00388425-3bb7-4c98-bec5-c57557565efc
[2024-06-02 16:08:09,587] [INFO] [org.apache.flink.runtime.io.network.buffer.NetworkBufferPool] [main] [] - Allocated 64 MB for network buffer pool (number of memory segments: 2048, bytes per segment: 32768).
[2024-06-02 16:08:09,597] [INFO] [org.apache.flink.runtime.io.network.NettyShuffleEnvironment] [main] [] - Starting the network environment and its components.
[2024-06-02 16:08:09,598] [INFO] [org.apache.flink.runtime.taskexecutor.KvStateService] [main] [] - Starting the kvState service and its components.
[2024-06-02 16:08:09,619] [INFO] [org.apache.flink.configuration.Configuration] [main] [] - Config uses fallback configuration key 'pekko.ask.timeout' instead of key 'taskmanager.slot.timeout'
[2024-06-02 16:08:09,627] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [main] [] - Starting RPC endpoint for org.apache.flink.runtime.taskexecutor.TaskExecutor at pekko://flink/user/rpc/taskmanager_0 .
[2024-06-02 16:08:09,641] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-4] [] - Start job leader service.
[2024-06-02 16:08:09,642] [INFO] [org.apache.flink.runtime.filecache.FileCache] [flink-pekko.actor.default-dispatcher-4] [] - User file cache uses directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-dist-cache-308eacf7-5b0a-44fe-8a3e-566d40eccc4c
[2024-06-02 16:08:09,688] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [main] [] - Starting rest endpoint.
[2024-06-02 16:08:09,942] [WARN] [org.apache.flink.runtime.webmonitor.WebMonitorUtils] [main] [] - Log file environment variable 'log.file' is not set.
[2024-06-02 16:08:09,942] [WARN] [org.apache.flink.runtime.webmonitor.WebMonitorUtils] [main] [] - JobManager log files are unavailable in the web dashboard. Log file location not found in environment variable 'log.file' or configuration key 'web.log.path'.
[2024-06-02 16:08:10,048] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [main] [] - Rest endpoint listening at localhost:56948
[2024-06-02 16:08:10,049] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [main] [] - Proposing leadership to the contender that is registered under component ID 'rest_server'.
[2024-06-02 16:08:10,051] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [main] [] - Web frontend listening at http://localhost:56948.
[2024-06-02 16:08:10,051] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [mini-cluster-io-thread-1] [] - http://localhost:56948 was granted leadership with leaderSessionID=b382e539-aac0-41b1-b595-04d9fd7d86f0
[2024-06-02 16:08:10,051] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [mini-cluster-io-thread-1] [] - Received confirmation of leadership for leader http://localhost:56948 , session=b382e539-aac0-41b1-b595-04d9fd7d86f0
[2024-06-02 16:08:10,061] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [main] [] - Proposing leadership to the contender that is registered under component ID 'dispatcher'.
[2024-06-02 16:08:10,061] [INFO] [org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl] [main] [] - Starting resource manager service.
[2024-06-02 16:08:10,061] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [main] [] - Proposing leadership to the contender that is registered under component ID 'resource_manager'.
[2024-06-02 16:08:10,061] [INFO] [org.apache.flink.runtime.dispatcher.runner.DefaultDispatcherRunner] [mini-cluster-io-thread-2] [] - DefaultDispatcherRunner was granted leadership with leader id 056b46af-51bb-40e4-b162-de3c530a162d. Creating new DispatcherLeaderProcess.
[2024-06-02 16:08:10,062] [INFO] [org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl] [pool-2-thread-1] [] - Resource manager service is granted leadership with session id 81e16f3f-6b1e-4fe5-a2b0-a40941ec9d97.
[2024-06-02 16:08:10,063] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [main] [] - Flink Mini Cluster started successfully
[2024-06-02 16:08:10,065] [INFO] [org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcess] [mini-cluster-io-thread-2] [] - Start SessionDispatcherLeaderProcess.
[2024-06-02 16:08:10,068] [INFO] [org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcess] [mini-cluster-io-thread-1] [] - Recover all persisted job graphs that are not finished, yet.
[2024-06-02 16:08:10,068] [INFO] [org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcess] [mini-cluster-io-thread-1] [] - Successfully recovered 0 persisted job graphs.
[2024-06-02 16:08:10,077] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [pool-2-thread-1] [] - Starting RPC endpoint for org.apache.flink.runtime.resourcemanager.StandaloneResourceManager at pekko://flink/user/rpc/resourcemanager_1 .
[2024-06-02 16:08:10,080] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [mini-cluster-io-thread-1] [] - Starting RPC endpoint for org.apache.flink.runtime.dispatcher.StandaloneDispatcher at pekko://flink/user/rpc/dispatcher_2 .
[2024-06-02 16:08:10,090] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-4] [] - Starting the resource manager.
[2024-06-02 16:08:10,093] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Starting the slot manager.
[2024-06-02 16:08:10,094] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [flink-pekko.actor.default-dispatcher-4] [] - Starting tokens update task
[2024-06-02 16:08:10,094] [WARN] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [flink-pekko.actor.default-dispatcher-4] [] - No tokens obtained so skipping notifications
[2024-06-02 16:08:10,094] [WARN] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [flink-pekko.actor.default-dispatcher-4] [] - Tokens update task not started because either no tokens obtained or none of the tokens specified its renewal date
[2024-06-02 16:08:10,094] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [mini-cluster-io-thread-4] [] - Received confirmation of leadership for leader pekko://flink/user/rpc/resourcemanager_1 , session=81e16f3f-6b1e-4fe5-a2b0-a40941ec9d97
[2024-06-02 16:08:10,095] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-4] [] - Connecting to ResourceManager pekko://flink/user/rpc/resourcemanager_1(a2b0a40941ec9d9781e16f3f6b1e4fe5).
[2024-06-02 16:08:10,096] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [mini-cluster-io-thread-1] [] - Received confirmation of leadership for leader pekko://flink/user/rpc/dispatcher_2 , session=056b46af-51bb-40e4-b162-de3c530a162d
[2024-06-02 16:08:10,115] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Resolved ResourceManager address, beginning registration
[2024-06-02 16:08:10,122] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-4] [] - Registering TaskManager with ResourceID 47893016-4df0-472e-bd91-8e8cc5cd9e5d (pekko://flink/user/rpc/taskmanager_0) at ResourceManager
[2024-06-02 16:08:10,123] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Successful registration at resource manager pekko://flink/user/rpc/resourcemanager_1 under registration id ccedeabdee2126031256c17d17caad5a.
[2024-06-02 16:08:10,124] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-8] [] - Received JobGraph submission 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,124] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-8] [] - Submitting job 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,124] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Registering task executor 47893016-4df0-472e-bd91-8e8cc5cd9e5d under ccedeabdee2126031256c17d17caad5a at the slot manager.
[2024-06-02 16:08:10,134] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [flink-pekko.actor.default-dispatcher-8] [] - Proposing leadership to the contender that is registered under component ID 'job-25415b4834220fc5d46b428a90e38422'.
[2024-06-02 16:08:10,135] [INFO] [org.apache.flink.runtime.jobmaster.JobMasterServiceLeadershipRunner] [mini-cluster-io-thread-4] [] - JobMasterServiceLeadershipRunner for job 25415b4834220fc5d46b428a90e38422 was granted leadership with leader id 22080d07-1fa9-4ae9-8922-7b8868e0fb10. Creating new JobMasterServiceProcess.
[2024-06-02 16:08:10,142] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [jobmanager-io-thread-1] [] - Starting RPC endpoint for org.apache.flink.runtime.jobmaster.JobMaster at pekko://flink/user/rpc/jobmanager_3 .
[2024-06-02 16:08:10,148] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [jobmanager-io-thread-1] [] - Initializing job 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,166] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [jobmanager-io-thread-1] [] - Using restart back off time strategy NoRestartBackoffTimeStrategy for Flink Java Job at Sun Jun 02 16:08:08 JST 2024 (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,189] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [jobmanager-io-thread-1] [] - Created execution graph 25a8a172f577ee115b99d275ee48f3a9 for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,206] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [jobmanager-io-thread-1] [] - Running initialization on master for job Flink Java Job at Sun Jun 02 16:08:08 JST 2024 (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,209] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [jobmanager-io-thread-1] [] - Successfully ran initialization on master in 3 ms.
[2024-06-02 16:08:10,251] [INFO] [org.apache.flink.runtime.scheduler.adapter.DefaultExecutionTopology] [jobmanager-io-thread-1] [] - Built 1 new pipelined regions in 1 ms, total 1 pipelined regions currently.
[2024-06-02 16:08:10,261] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [jobmanager-io-thread-1] [] - Using failover strategy org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy@58e30699 for Flink Java Job at Sun Jun 02 16:08:08 JST 2024 (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,272] [INFO] [org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService] [jobmanager-io-thread-1] [] - Received confirmation of leadership for leader pekko://flink/user/rpc/jobmanager_3 , session=22080d07-1fa9-4ae9-8922-7b8868e0fb10
[2024-06-02 16:08:10,275] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-7] [] - Starting execution of job 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422) under job master id 89227b8868e0fb1022080d071fa94ae9.
[2024-06-02 16:08:10,277] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-7] [] - Starting scheduling with scheduling strategy [org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy]
[2024-06-02 16:08:10,277] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Job Flink Java Job at Sun Jun 02 16:08:08 JST 2024 (25415b4834220fc5d46b428a90e38422) switched from state CREATED to RUNNING.
[2024-06-02 16:08:10,280] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (1/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (2/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (3/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (4/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (5/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (6/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,281] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (7/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (8/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (9/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (10/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (11/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (12/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (13/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (14/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (15/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,282] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (16/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (1/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (2/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (3/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (4/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (5/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (6/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (7/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (8/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (9/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,283] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (10/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,284] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (11/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,284] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (12/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,284] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (13/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,285] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (14/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,285] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (15/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,285] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (16/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from CREATED to SCHEDULED.
[2024-06-02 16:08:10,310] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-7] [] - Connecting to ResourceManager pekko://flink/user/rpc/resourcemanager_1(a2b0a40941ec9d9781e16f3f6b1e4fe5)
[2024-06-02 16:08:10,312] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-6] [] - Resolved ResourceManager address, beginning registration
[2024-06-02 16:08:10,313] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-6] [] - Registering job manager 89227b8868e0fb1022080d071fa94ae9@pekko://flink/user/rpc/jobmanager_3 for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,318] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-7] [] - Registered job manager 89227b8868e0fb1022080d071fa94ae9@pekko://flink/user/rpc/jobmanager_3 for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,319] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-6] [] - JobManager successfully registered at ResourceManager, leader id: a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,321] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-7] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=16}]
[2024-06-02 16:08:10,387] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Matching resource requirements against available resources.
Missing resources:
	 Job 25415b4834220fc5d46b428a90e38422
		ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=16}
Current resources:
	TaskManager 47893016-4df0-472e-bd91-8e8cc5cd9e5d
		Available: ResourceProfile{taskHeapMemory=1024.000gb (1099511627776 bytes), taskOffHeapMemory=1024.000gb (1099511627776 bytes), managedMemory=128.000mb (134217728 bytes), networkMemory=64.000mb (67108864 bytes)}
		Total:     ResourceProfile{taskHeapMemory=1024.000gb (1099511627776 bytes), taskOffHeapMemory=1024.000gb (1099511627776 bytes), managedMemory=128.000mb (134217728 bytes), networkMemory=64.000mb (67108864 bytes)}
[2024-06-02 16:08:10,393] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 47f074928755580972ca9a26425593b1 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,396] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 47f074928755580972ca9a26425593b1 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,397] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 47f074928755580972ca9a26425593b1 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,398] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot aa7495a2f5e669d39cff22306f6ed846 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,399] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 6e6c74038fce9c541bcd94155631ec8c from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,400] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 54bdadb7b7d6ef9b5e39556c5e3bec2f from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,401] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 044a4822865be13474edf4c4e2c73ae7 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,402] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 565eddca7a050096b2b9970f1543f00a from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,402] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-7] [] - Add job 25415b4834220fc5d46b428a90e38422 for job leader monitoring.
[2024-06-02 16:08:10,403] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 46af645cc3fcd6e00c765739e2d2e768 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,403] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 954bcef6959315c4be377c1c4d208b57 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,404] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot cfc610a2f55e41c34979a8978959ac0c from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,404] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [mini-cluster-io-thread-4] [] - Try to register at job manager pekko://flink/user/rpc/jobmanager_3 with leader id 22080d07-1fa9-4ae9-8922-7b8868e0fb10.
[2024-06-02 16:08:10,404] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot d2574321d1914b9a3a6369fcf8c5f82c from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot ea69f5ea478cccfb2b15c8aa8338eaa2 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request aa7495a2f5e669d39cff22306f6ed846 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for aa7495a2f5e669d39cff22306f6ed846 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot e5cbe97264fadc80f9e2befbed4341b2 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-4] [] - Resolved JobManager address, beginning registration
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 6e6c74038fce9c541bcd94155631ec8c for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,405] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 6e6c74038fce9c541bcd94155631ec8c with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,406] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 5529baac283facdc0439ba5fb01c534e from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,406] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 54bdadb7b7d6ef9b5e39556c5e3bec2f for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,406] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 54bdadb7b7d6ef9b5e39556c5e3bec2f with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,406] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot b19b42d2dbf86b53c2788ac970dbd2a8 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,407] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 044a4822865be13474edf4c4e2c73ae7 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,407] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 044a4822865be13474edf4c4e2c73ae7 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,407] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot 842faf6666e5116b4ad1644a1d11db08 from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,407] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 565eddca7a050096b2b9970f1543f00a for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,408] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 565eddca7a050096b2b9970f1543f00a with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,408] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 46af645cc3fcd6e00c765739e2d2e768 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,408] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Starting allocation of slot ffd4967316311de4e15cd6f9a55453df from 47893016-4df0-472e-bd91-8e8cc5cd9e5d for job 25415b4834220fc5d46b428a90e38422 with resource profile ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,408] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 46af645cc3fcd6e00c765739e2d2e768 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,408] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 954bcef6959315c4be377c1c4d208b57 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,409] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 954bcef6959315c4be377c1c4d208b57 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,409] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request cfc610a2f55e41c34979a8978959ac0c for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,409] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for cfc610a2f55e41c34979a8978959ac0c with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,409] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request d2574321d1914b9a3a6369fcf8c5f82c for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,410] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for d2574321d1914b9a3a6369fcf8c5f82c with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,410] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request ea69f5ea478cccfb2b15c8aa8338eaa2 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,410] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for ea69f5ea478cccfb2b15c8aa8338eaa2 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,410] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request e5cbe97264fadc80f9e2befbed4341b2 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,410] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for e5cbe97264fadc80f9e2befbed4341b2 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,411] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 5529baac283facdc0439ba5fb01c534e for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,411] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 5529baac283facdc0439ba5fb01c534e with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,411] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request b19b42d2dbf86b53c2788ac970dbd2a8 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,411] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for b19b42d2dbf86b53c2788ac970dbd2a8 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,412] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request 842faf6666e5116b4ad1644a1d11db08 for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,412] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for 842faf6666e5116b4ad1644a1d11db08 with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,412] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Receive slot request ffd4967316311de4e15cd6f9a55453df for job 25415b4834220fc5d46b428a90e38422 from resource manager with leader id a2b0a40941ec9d9781e16f3f6b1e4fe5.
[2024-06-02 16:08:10,413] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Allocated slot for ffd4967316311de4e15cd6f9a55453df with resources ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}.
[2024-06-02 16:08:10,417] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-6] [] - Successful registration at job manager pekko://flink/user/rpc/jobmanager_3 for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,418] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Establish JobManager connection for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,421] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Offer reserved slots to the leader of job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,437] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,438] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0 and vertex id 95c6d1234261b714433a5011ccc1067b_0 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id cfc610a2f55e41c34979a8978959ac0c
[2024-06-02 16:08:10,442] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (1/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,442] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (1/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0 and vertex id 4532822eac92c4ae2092918fc65c6879_0 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id cfc610a2f55e41c34979a8978959ac0c
[2024-06-02 16:08:10,442] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,456] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (2/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,456] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (2/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0 and vertex id 4532822eac92c4ae2092918fc65c6879_1 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 5529baac283facdc0439ba5fb01c534e
[2024-06-02 16:08:10,456] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (3/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,457] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (3/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0 and vertex id 4532822eac92c4ae2092918fc65c6879_2 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id b19b42d2dbf86b53c2788ac970dbd2a8
[2024-06-02 16:08:10,457] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (4/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,457] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (4/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0 and vertex id 4532822eac92c4ae2092918fc65c6879_3 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 044a4822865be13474edf4c4e2c73ae7
[2024-06-02 16:08:10,458] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (5/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,458] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (5/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0 and vertex id 4532822eac92c4ae2092918fc65c6879_4 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 954bcef6959315c4be377c1c4d208b57
[2024-06-02 16:08:10,464] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (6/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,464] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (6/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0 and vertex id 4532822eac92c4ae2092918fc65c6879_5 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 565eddca7a050096b2b9970f1543f00a
[2024-06-02 16:08:10,465] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (7/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,465] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (7/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0 and vertex id 4532822eac92c4ae2092918fc65c6879_6 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id ea69f5ea478cccfb2b15c8aa8338eaa2
[2024-06-02 16:08:10,465] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (8/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,466] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (8/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0 and vertex id 4532822eac92c4ae2092918fc65c6879_7 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id e5cbe97264fadc80f9e2befbed4341b2
[2024-06-02 16:08:10,466] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (9/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,466] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (9/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0 and vertex id 4532822eac92c4ae2092918fc65c6879_8 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id d2574321d1914b9a3a6369fcf8c5f82c
[2024-06-02 16:08:10,467] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (10/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,467] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (10/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0 and vertex id 4532822eac92c4ae2092918fc65c6879_9 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 46af645cc3fcd6e00c765739e2d2e768
[2024-06-02 16:08:10,467] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (11/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,467] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (11/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0 and vertex id 4532822eac92c4ae2092918fc65c6879_10 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 54bdadb7b7d6ef9b5e39556c5e3bec2f
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader] [flink-pekko.actor.default-dispatcher-6] [] - StateChangelogStorageLoader initialized with shortcut names {memory}.
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader] [flink-pekko.actor.default-dispatcher-6] [] - Creating a changelog storage with name 'memory'.
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (12/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (12/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0 and vertex id 4532822eac92c4ae2092918fc65c6879_11 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 47f074928755580972ca9a26425593b1
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (13/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,468] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (13/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0 and vertex id 4532822eac92c4ae2092918fc65c6879_12 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id aa7495a2f5e669d39cff22306f6ed846
[2024-06-02 16:08:10,469] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (14/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,469] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (14/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0 and vertex id 4532822eac92c4ae2092918fc65c6879_13 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id ffd4967316311de4e15cd6f9a55453df
[2024-06-02 16:08:10,469] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (15/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,469] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (15/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0 and vertex id 4532822eac92c4ae2092918fc65c6879_14 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 6e6c74038fce9c541bcd94155631ec8c
[2024-06-02 16:08:10,470] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (16/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,470] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying Reduce (SUM(1)) (16/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0 and vertex id 4532822eac92c4ae2092918fc65c6879_15 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 842faf6666e5116b4ad1644a1d11db08
[2024-06-02 16:08:10,470] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (1/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,470] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (1/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0 and vertex id 384e428f1fd31d0af84163fd671705d0_0 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id cfc610a2f55e41c34979a8978959ac0c
[2024-06-02 16:08:10,471] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (2/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,471] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (2/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0 and vertex id 384e428f1fd31d0af84163fd671705d0_1 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 5529baac283facdc0439ba5fb01c534e
[2024-06-02 16:08:10,472] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (3/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,472] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (3/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0 and vertex id 384e428f1fd31d0af84163fd671705d0_2 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id b19b42d2dbf86b53c2788ac970dbd2a8
[2024-06-02 16:08:10,473] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (4/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,473] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (4/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0 and vertex id 384e428f1fd31d0af84163fd671705d0_3 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 044a4822865be13474edf4c4e2c73ae7
[2024-06-02 16:08:10,474] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (5/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,474] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (5/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0 and vertex id 384e428f1fd31d0af84163fd671705d0_4 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 954bcef6959315c4be377c1c4d208b57
[2024-06-02 16:08:10,475] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (6/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,475] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (6/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0 and vertex id 384e428f1fd31d0af84163fd671705d0_5 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 565eddca7a050096b2b9970f1543f00a
[2024-06-02 16:08:10,476] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (7/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,476] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (7/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0 and vertex id 384e428f1fd31d0af84163fd671705d0_6 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id ea69f5ea478cccfb2b15c8aa8338eaa2
[2024-06-02 16:08:10,477] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (8/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,477] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (8/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0 and vertex id 384e428f1fd31d0af84163fd671705d0_7 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id e5cbe97264fadc80f9e2befbed4341b2
[2024-06-02 16:08:10,478] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (9/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,478] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (9/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0 and vertex id 384e428f1fd31d0af84163fd671705d0_8 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id d2574321d1914b9a3a6369fcf8c5f82c
[2024-06-02 16:08:10,478] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (10/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,478] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (10/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0 and vertex id 384e428f1fd31d0af84163fd671705d0_9 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 46af645cc3fcd6e00c765739e2d2e768
[2024-06-02 16:08:10,479] [INFO] [org.apache.flink.runtime.state.TaskExecutorChannelStateExecutorFactoryManager] [flink-pekko.actor.default-dispatcher-6] [] - Creating the channel state executor factory for job id 25415b4834220fc5d46b428a90e38422
[2024-06-02 16:08:10,479] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (11/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,479] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (11/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0 and vertex id 384e428f1fd31d0af84163fd671705d0_10 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 54bdadb7b7d6ef9b5e39556c5e3bec2f
[2024-06-02 16:08:10,480] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (12/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,480] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (12/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0 and vertex id 384e428f1fd31d0af84163fd671705d0_11 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 47f074928755580972ca9a26425593b1
[2024-06-02 16:08:10,481] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (13/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,481] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (13/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0 and vertex id 384e428f1fd31d0af84163fd671705d0_12 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id aa7495a2f5e669d39cff22306f6ed846
[2024-06-02 16:08:10,482] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (14/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,482] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (14/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0 and vertex id 384e428f1fd31d0af84163fd671705d0_13 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id ffd4967316311de4e15cd6f9a55453df
[2024-06-02 16:08:10,483] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (15/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,483] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (15/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0 and vertex id 384e428f1fd31d0af84163fd671705d0_14 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 6e6c74038fce9c541bcd94155631ec8c
[2024-06-02 16:08:10,484] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (16/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from SCHEDULED to DEPLOYING.
[2024-06-02 16:08:10,484] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Deploying DataSink (collect()) (16/16) (attempt #0) with attempt id 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0 and vertex id 384e428f1fd31d0af84163fd671705d0_15 to 47893016-4df0-472e-bd91-8e8cc5cd9e5d @ localhost (dataPort=-1) with allocation id 842faf6666e5116b4ad1644a1d11db08
[2024-06-02 16:08:10,495] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0), deploy into slot with allocation id cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,496] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,498] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,499] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - Loading JAR files for task CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) [DEPLOYING].
[2024-06-02 16:08:10,513] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0), deploy into slot with allocation id cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,514] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,515] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) [DEPLOYING].
[2024-06-02 16:08:10,515] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,520] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0), deploy into slot with allocation id 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,521] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,521] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) [DEPLOYING].
[2024-06-02 16:08:10,521] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,524] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0), deploy into slot with allocation id b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,525] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,525] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,525] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) [DEPLOYING].
[2024-06-02 16:08:10,526] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,527] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,527] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,529] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,529] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,530] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,530] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,530] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,529] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,530] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0), deploy into slot with allocation id 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,530] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,531] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (1/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,531] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,532] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,532] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (3/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,532] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) [DEPLOYING].
[2024-06-02 16:08:10,532] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (2/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (3/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (1/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (2/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,533] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (4/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,534] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (4/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,536] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0), deploy into slot with allocation id 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,537] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,537] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) [DEPLOYING].
[2024-06-02 16:08:10,537] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,538] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,538] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,539] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (5/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,539] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (5/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,541] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0), deploy into slot with allocation id 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,541] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,541] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,541] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) [DEPLOYING].
[2024-06-02 16:08:10,543] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,551] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,552] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (6/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,552] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (6/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,554] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0), deploy into slot with allocation id ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,555] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,555] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) [DEPLOYING].
[2024-06-02 16:08:10,555] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,556] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,556] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,556] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (7/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,557] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (7/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,559] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0), deploy into slot with allocation id e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,562] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,562] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,562] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) [DEPLOYING].
[2024-06-02 16:08:10,563] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,564] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,564] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (8/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,565] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (8/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,565] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0), deploy into slot with allocation id d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,567] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,567] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,567] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) [DEPLOYING].
[2024-06-02 16:08:10,568] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,569] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,569] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (9/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,570] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0), deploy into slot with allocation id 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,570] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (9/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,571] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,571] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,571] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) [DEPLOYING].
[2024-06-02 16:08:10,573] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,573] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,574] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0), deploy into slot with allocation id 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,574] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (10/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,578] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - Reduce (SUM(1)) (10/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,578] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,579] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) [DEPLOYING].
[2024-06-02 16:08:10,580] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,580] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (11/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,580] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,581] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (11/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,589] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,591] [WARN] [org.apache.flink.metrics.MetricGroup] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - The operator name DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) exceeded the 80 characters length limit and was truncated.
[2024-06-02 16:08:10,593] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0), deploy into slot with allocation id 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,593] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,593] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) [DEPLOYING].
[2024-06-02 16:08:10,593] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,594] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,595] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,595] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (12/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,595] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (12/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,596] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0), deploy into slot with allocation id aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,596] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,596] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) [DEPLOYING].
[2024-06-02 16:08:10,597] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-6] [] - Activate slot ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,597] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,598] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,598] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (13/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,598] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (13/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,599] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-6] [] - Received task Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0), deploy into slot with allocation id ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,599] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,599] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) [DEPLOYING].
[2024-06-02 16:08:10,599] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,600] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,601] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,601] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (14/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,601] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - Reduce (SUM(1)) (14/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,602] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0), deploy into slot with allocation id 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,602] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,602] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) [DEPLOYING].
[2024-06-02 16:08:10,602] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,603] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,604] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,604] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - Reduce (SUM(1)) (15/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,604] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - Reduce (SUM(1)) (15/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,605] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0), deploy into slot with allocation id 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,605] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,605] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Loading JAR files for task Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) [DEPLOYING].
[2024-06-02 16:08:10,605] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,606] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,606] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,606] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - Reduce (SUM(1)) (16/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,607] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - Reduce (SUM(1)) (16/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,607] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0), deploy into slot with allocation id cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,609] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,609] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - Loading JAR files for task DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) [DEPLOYING].
[2024-06-02 16:08:10,610] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,611] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,611] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0), deploy into slot with allocation id 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,611] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,611] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (1/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,612] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (1/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,614] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,614] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,614] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - Loading JAR files for task DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) [DEPLOYING].
[2024-06-02 16:08:10,614] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,615] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,615] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (2/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,615] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (2/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,616] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0), deploy into slot with allocation id b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,616] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,616] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,616] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - Loading JAR files for task DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) [DEPLOYING].
[2024-06-02 16:08:10,617] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,617] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,617] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (3/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,617] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (3/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,618] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0), deploy into slot with allocation id 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,618] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,618] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - Loading JAR files for task DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) [DEPLOYING].
[2024-06-02 16:08:10,618] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,619] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,619] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,619] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (4/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,619] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (4/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskmanager.Task] [CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0] [] - Freeing task resources for CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0).
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0), deploy into slot with allocation id 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - Loading JAR files for task DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) [DEPLOYING].
[2024-06-02 16:08:10,620] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,621] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,621] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,622] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (5/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,622] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-4] [] - DataSink (collect()) (5/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,624] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0), deploy into slot with allocation id 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,624] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,624] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - Loading JAR files for task DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) [DEPLOYING].
[2024-06-02 16:08:10,624] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,625] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,625] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,625] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (6/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,625] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (6/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,626] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0), deploy into slot with allocation id ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,626] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,626] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - Loading JAR files for task DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) [DEPLOYING].
[2024-06-02 16:08:10,626] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,628] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,628] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,628] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (7/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,628] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (7/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,629] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0), deploy into slot with allocation id e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,629] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,629] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,629] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - Loading JAR files for task DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) [DEPLOYING].
[2024-06-02 16:08:10,630] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,630] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,631] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (8/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,631] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (8/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (1/16)#0] [] - Freeing task resources for DataSink (collect()) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0).
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (1/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (1/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0).
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0), deploy into slot with allocation id d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (6/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0).
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (4/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0).
[2024-06-02 16:08:10,632] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (8/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (14/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (4/16)#0] [] - Freeing task resources for DataSink (collect()) (4/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (15/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (6/16)#0] [] - Freeing task resources for DataSink (collect()) (6/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (8/16)#0] [] - Freeing task resources for DataSink (collect()) (8/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (13/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (11/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - Loading JAR files for task DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) [DEPLOYING].
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (3/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0).
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,633] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (5/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (3/16)#0] [] - Freeing task resources for DataSink (collect()) (3/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (5/16)#0] [] - Freeing task resources for DataSink (collect()) (5/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (10/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (9/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (9/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (12/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0).
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-6] [] - DataSink (collect()) (9/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,634] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (2/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0).
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (7/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0).
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [Reduce (SUM(1)) (16/16)#0] [] - Freeing task resources for Reduce (SUM(1)) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0).
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (2/16)#0] [] - Freeing task resources for DataSink (collect()) (2/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0).
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,635] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (7/16)#0] [] - Freeing task resources for DataSink (collect()) (7/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0).
[2024-06-02 16:08:10,640] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,640] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (9/16)#0] [] - Freeing task resources for DataSink (collect()) (9/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0).
[2024-06-02 16:08:10,645] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0), deploy into slot with allocation id 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,646] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,646] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,647] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - Loading JAR files for task DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) [DEPLOYING].
[2024-06-02 16:08:10,647] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,648] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,648] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (10/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,648] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (10/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,648] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0), deploy into slot with allocation id 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,649] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,649] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - Loading JAR files for task DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) [DEPLOYING].
[2024-06-02 16:08:10,649] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,650] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,650] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,650] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (11/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,651] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (11/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,651] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,651] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (10/16)#0] [] - Freeing task resources for DataSink (collect()) (10/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0).
[2024-06-02 16:08:10,651] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0), deploy into slot with allocation id 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,652] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,652] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - Loading JAR files for task DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) [DEPLOYING].
[2024-06-02 16:08:10,652] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-7] [] - Activate slot aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,652] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,653] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,653] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (12/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,653] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-8] [] - DataSink (collect()) (12/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,653] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,653] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (11/16)#0] [] - Freeing task resources for DataSink (collect()) (11/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0).
[2024-06-02 16:08:10,654] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-7] [] - Received task DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0), deploy into slot with allocation id aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,654] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,654] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - Loading JAR files for task DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) [DEPLOYING].
[2024-06-02 16:08:10,655] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,655] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,655] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,655] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (12/16)#0] [] - Freeing task resources for DataSink (collect()) (12/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0).
[2024-06-02 16:08:10,656] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,656] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (13/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,656] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (13/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,657] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Received task DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0), deploy into slot with allocation id ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,658] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,659] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - Loading JAR files for task DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) [DEPLOYING].
[2024-06-02 16:08:10,659] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (13/16)#0] [] - Freeing task resources for DataSink (collect()) (13/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0).
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (14/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,660] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (14/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,661] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Received task DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0), deploy into slot with allocation id 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,662] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,662] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - Loading JAR files for task DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) [DEPLOYING].
[2024-06-02 16:08:10,662] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,663] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,663] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,663] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,663] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (14/16)#0] [] - Freeing task resources for DataSink (collect()) (14/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0).
[2024-06-02 16:08:10,663] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (15/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,664] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (15/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,664] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Received task DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0), deploy into slot with allocation id 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,665] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from CREATED to DEPLOYING.
[2024-06-02 16:08:10,665] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - Loading JAR files for task DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) [DEPLOYING].
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Activate slot ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1)#0 25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (15/16)#0] [] - Freeing task resources for DataSink (collect()) (15/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0).
[2024-06-02 16:08:10,666] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (16/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from DEPLOYING to INITIALIZING.
[2024-06-02 16:08:10,667] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (16/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from INITIALIZING to RUNNING.
[2024-06-02 16:08:10,670] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,670] [INFO] [org.apache.flink.runtime.taskmanager.Task] [DataSink (collect()) (16/16)#0] [] - Freeing task resources for DataSink (collect()) (16/16)#0 (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0).
[2024-06-02 16:08:10,681] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (1/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0.
[2024-06-02 16:08:10,683] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - CHAIN DataSource (at org.apache.flink.api.scala.ExecutionEnvironment.fromElements(ExecutionEnvironment.scala:437) (org.apache.flink.api.java.io.CollectionInputFormat)) -> FlatMap (FlatMap at Main$.main(Main.scala:16)) -> Map (Map at Main$.main(Main.scala:17)) -> Combine (SUM(1)) (1/1) (25a8a172f577ee115b99d275ee48f3a9_95c6d1234261b714433a5011ccc1067b_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,683] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (6/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0.
[2024-06-02 16:08:10,684] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (6/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0.
[2024-06-02 16:08:10,684] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (8/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0.
[2024-06-02 16:08:10,684] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (15/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0.
[2024-06-02 16:08:10,685] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (13/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0.
[2024-06-02 16:08:10,686] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (11/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0.
[2024-06-02 16:08:10,687] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (3/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0.
[2024-06-02 16:08:10,688] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (1/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,688] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (5/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0.
[2024-06-02 16:08:10,688] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (6/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_5_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,689] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (3/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0.
[2024-06-02 16:08:10,689] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (10/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0.
[2024-06-02 16:08:10,690] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (6/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_5_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,690] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (1/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0.
[2024-06-02 16:08:10,691] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (5/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0.
[2024-06-02 16:08:10,691] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (8/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0.
[2024-06-02 16:08:10,691] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (4/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0.
[2024-06-02 16:08:10,692] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (9/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0.
[2024-06-02 16:08:10,693] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (12/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0.
[2024-06-02 16:08:10,693] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (4/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0.
[2024-06-02 16:08:10,694] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=15}]
[2024-06-02 16:08:10,694] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (2/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0.
[2024-06-02 16:08:10,695] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (8/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_7_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,695] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (14/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0.
[2024-06-02 16:08:10,697] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (7/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0.
[2024-06-02 16:08:10,698] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (15/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_14_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,698] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task Reduce (SUM(1)) (16/16)#0 25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0.
[2024-06-02 16:08:10,699] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (13/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_12_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,699] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (2/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0.
[2024-06-02 16:08:10,700] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (7/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0.
[2024-06-02 16:08:10,700] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (11/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_10_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,700] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (9/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0.
[2024-06-02 16:08:10,701] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (10/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0.
[2024-06-02 16:08:10,701] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (3/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_2_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,702] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (11/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0.
[2024-06-02 16:08:10,702] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (12/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0.
[2024-06-02 16:08:10,703] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (5/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_4_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,703] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (13/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0.
[2024-06-02 16:08:10,704] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (3/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_2_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,704] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (14/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0.
[2024-06-02 16:08:10,704] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (15/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0.
[2024-06-02 16:08:10,704] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=14}]
[2024-06-02 16:08:10,705] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Un-registering task and sending final execution state FINISHED to JobManager for task DataSink (collect()) (16/16)#0 25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0.
[2024-06-02 16:08:10,705] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (10/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_9_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,706] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (1/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_0_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,707] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-8] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=13}]
[2024-06-02 16:08:10,708] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (5/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_4_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,708] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=12}]
[2024-06-02 16:08:10,709] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (8/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_7_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,709] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=11}]
[2024-06-02 16:08:10,710] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (4/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_3_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,711] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (9/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_8_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,712] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (12/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_11_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,712] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (4/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_3_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,713] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=10}]
[2024-06-02 16:08:10,713] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (2/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_1_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,714] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (14/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_13_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,714] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (7/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_6_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,715] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Reduce (SUM(1)) (16/16) (25a8a172f577ee115b99d275ee48f3a9_4532822eac92c4ae2092918fc65c6879_15_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,715] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (2/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_1_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,716] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=9}]
[2024-06-02 16:08:10,716] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (7/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_6_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,717] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=8}]
[2024-06-02 16:08:10,718] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (9/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_8_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,721] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=7}]
[2024-06-02 16:08:10,722] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (10/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_9_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,723] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=6}]
[2024-06-02 16:08:10,724] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (11/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_10_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,725] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-8] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=5}]
[2024-06-02 16:08:10,725] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (12/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_11_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,726] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-8] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=4}]
[2024-06-02 16:08:10,727] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (13/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_12_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,729] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=3}]
[2024-06-02 16:08:10,731] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (14/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_13_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,732] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-4] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=2}]
[2024-06-02 16:08:10,732] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (15/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_14_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,734] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Received resource requirements from job 25415b4834220fc5d46b428a90e38422: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=1}]
[2024-06-02 16:08:10,734] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - DataSink (collect()) (16/16) (25a8a172f577ee115b99d275ee48f3a9_384e428f1fd31d0af84163fd671705d0_15_0) switched from RUNNING to FINISHED.
[2024-06-02 16:08:10,736] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Clearing resource requirements of job 25415b4834220fc5d46b428a90e38422
[2024-06-02 16:08:10,741] [INFO] [org.apache.flink.runtime.executiongraph.ExecutionGraph] [flink-pekko.actor.default-dispatcher-7] [] - Job Flink Java Job at Sun Jun 02 16:08:08 JST 2024 (25415b4834220fc5d46b428a90e38422) switched from state RUNNING to FINISHED.
[2024-06-02 16:08:10,759] [INFO] [org.apache.flink.runtime.minicluster.MiniCluster] [flink-pekko.actor.default-dispatcher-7] [] - Shutting down Flink Mini Cluster
[2024-06-02 16:08:10,759] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-6] [] - Job 25415b4834220fc5d46b428a90e38422 reached terminal state FINISHED.
[2024-06-02 16:08:10,761] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Stopping TaskExecutor pekko://flink/user/rpc/taskmanager_0.
[2024-06-02 16:08:10,762] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Close ResourceManager connection 31c649a81bc46e99f310f2b83bdb43d8.
[2024-06-02 16:08:10,763] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [mini-cluster-io-thread-1] [] - Job 25415b4834220fc5d46b428a90e38422 has been registered for cleanup in the JobResultStore after reaching a terminal state.
[2024-06-02 16:08:10,763] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-6] [] - Closing TaskExecutor connection 47893016-4df0-472e-bd91-8e8cc5cd9e5d because: The TaskExecutor is shutting down.
[2024-06-02 16:08:10,763] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-6] [] - Unregistering task executor ccedeabdee2126031256c17d17caad5a from the slot manager.
[2024-06-02 16:08:10,763] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot b19b42d2dbf86b53c2788ac970dbd2a8.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot cfc610a2f55e41c34979a8978959ac0c.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot aa7495a2f5e669d39cff22306f6ed846.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 842faf6666e5116b4ad1644a1d11db08.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 54bdadb7b7d6ef9b5e39556c5e3bec2f.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot d2574321d1914b9a3a6369fcf8c5f82c.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot e5cbe97264fadc80f9e2befbed4341b2.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 044a4822865be13474edf4c4e2c73ae7.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 6e6c74038fce9c541bcd94155631ec8c.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot ea69f5ea478cccfb2b15c8aa8338eaa2.
[2024-06-02 16:08:10,764] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Close JobManager connection for job 25415b4834220fc5d46b428a90e38422.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 5529baac283facdc0439ba5fb01c534e.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 47f074928755580972ca9a26425593b1.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 954bcef6959315c4be377c1c4d208b57.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 565eddca7a050096b2b9970f1543f00a.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot 46af645cc3fcd6e00c765739e2d2e768.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer] [flink-pekko.actor.default-dispatcher-6] [] - Freeing slot ffd4967316311de4e15cd6f9a55453df.
[2024-06-02 16:08:10,765] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [flink-pekko.actor.default-dispatcher-7] [] - Shutting down rest endpoint.
[2024-06-02 16:08:10,769] [INFO] [org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down TaskExecutorStateChangelogStoragesManager.
[2024-06-02 16:08:10,770] [INFO] [org.apache.flink.runtime.state.TaskExecutorChannelStateExecutorFactoryManager] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down TaskExecutorChannelStateExecutorFactoryManager.
[2024-06-02 16:08:10,771] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-6] [] - Stopping the JobMaster for job 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,773] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:29, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: b19b42d2dbf86b53c2788ac970dbd2a8, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,775] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:24, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: cfc610a2f55e41c34979a8978959ac0c, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,775] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:17, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: aa7495a2f5e669d39cff22306f6ed846, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,776] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:30, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 842faf6666e5116b4ad1644a1d11db08, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,776] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-6] [] - Disconnect TaskExecutor 47893016-4df0-472e-bd91-8e8cc5cd9e5d because: The TaskExecutor is shutting down.
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:19, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 54bdadb7b7d6ef9b5e39556c5e3bec2f, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:25, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: d2574321d1914b9a3a6369fcf8c5f82c, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:27, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: e5cbe97264fadc80f9e2befbed4341b2, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:20, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 044a4822865be13474edf4c4e2c73ae7, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:18, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 6e6c74038fce9c541bcd94155631ec8c, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,777] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:26, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: ea69f5ea478cccfb2b15c8aa8338eaa2, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:28, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 5529baac283facdc0439ba5fb01c534e, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:16, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 47f074928755580972ca9a26425593b1, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [b19b42d2dbf86b53c2788ac970dbd2a8].
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:23, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 954bcef6959315c4be377c1c4d208b57, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:21, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 565eddca7a050096b2b9970f1543f00a, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:22, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: 46af645cc3fcd6e00c765739e2d2e768, jobId: 25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,778] [INFO] [org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl] [flink-pekko.actor.default-dispatcher-8] [] - Free slot TaskSlot(index:31, state:ALLOCATED, resource profile: ResourceProfile{taskHeapMemory=64.000gb (68719476736 bytes), taskOffHeapMemory=64.000gb (68719476736 bytes), managedMemory=8.000mb (8388608 bytes), networkMemory=4.000mb (4194304 bytes)}, allocationId: ffd4967316311de4e15cd6f9a55453df, jobId: 25415b4834220fc5d46b428a90e38422).
(a,1)
(in,1)
(or,2)
(arms,1)
[2024-06-02 16:08:10,780] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [cfc610a2f55e41c34979a8978959ac0c].
(the,3)
(and,1)
(arrows,1)
(be,2)
(nobler,1)
(of,2)
(slings,1)
(outrageous,1)
(is,1)
[2024-06-02 16:08:10,781] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [aa7495a2f5e669d39cff22306f6ed846].
(mind,1)
(against,1)
(not,1)
(sea,1)
(troubles,1)
(fortune,1)
(take,1)
(to,4)
(suffer,1)
(tis,1)
(whether,1)
[2024-06-02 16:08:10,782] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [842faf6666e5116b4ad1644a1d11db08].
(question,1)
(that,1)
[2024-06-02 16:08:10,782] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [54bdadb7b7d6ef9b5e39556c5e3bec2f].
[2024-06-02 16:08:10,782] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [d2574321d1914b9a3a6369fcf8c5f82c].
[2024-06-02 16:08:10,783] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [e5cbe97264fadc80f9e2befbed4341b2].
[2024-06-02 16:08:10,783] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [044a4822865be13474edf4c4e2c73ae7].
[2024-06-02 16:08:10,783] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [6e6c74038fce9c541bcd94155631ec8c].
[2024-06-02 16:08:10,783] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [ea69f5ea478cccfb2b15c8aa8338eaa2].
[2024-06-02 16:08:10,784] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [5529baac283facdc0439ba5fb01c534e].
[2024-06-02 16:08:10,784] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [47f074928755580972ca9a26425593b1].
[2024-06-02 16:08:10,784] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [954bcef6959315c4be377c1c4d208b57].
[2024-06-02 16:08:10,784] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [565eddca7a050096b2b9970f1543f00a].
[2024-06-02 16:08:10,785] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [46af645cc3fcd6e00c765739e2d2e768].
[2024-06-02 16:08:10,785] [INFO] [org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool] [flink-pekko.actor.default-dispatcher-6] [] - Releasing slot [ffd4967316311de4e15cd6f9a55453df].
[2024-06-02 16:08:10,785] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-8] [] - Stop job leader service.
[2024-06-02 16:08:10,785] [INFO] [org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down TaskExecutorLocalStateStoresManager.
[2024-06-02 16:08:10,785] [INFO] [org.apache.flink.runtime.jobmaster.JobMaster] [flink-pekko.actor.default-dispatcher-6] [] - Close ResourceManager connection 31c649a81bc46e99f310f2b83bdb43d8: Stopping JobMaster for job 'Flink Java Job at Sun Jun 02 16:08:08 JST 2024' (25415b4834220fc5d46b428a90e38422).
[2024-06-02 16:08:10,787] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-7] [] - Disconnect job manager 89227b8868e0fb1022080d071fa94ae9@pekko://flink/user/rpc/jobmanager_3 for job 25415b4834220fc5d46b428a90e38422 from the resource manager.
[2024-06-02 16:08:10,791] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [ForkJoinPool.commonPool-worker-2] [] - Removing cache directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-web-ui
[2024-06-02 16:08:10,792] [INFO] [org.apache.flink.runtime.io.disk.FileChannelManagerImpl] [flink-pekko.actor.default-dispatcher-8] [] - FileChannelManager removed spill file directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-io-211b9d60-f45d-4af3-9d82-0d92cd5e8238
[2024-06-02 16:08:10,792] [INFO] [org.apache.flink.runtime.io.network.NettyShuffleEnvironment] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down the network environment and its components.
[2024-06-02 16:08:10,793] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [ForkJoinPool.commonPool-worker-2] [] - http://localhost:56948 lost leadership
[2024-06-02 16:08:10,796] [INFO] [org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint] [ForkJoinPool.commonPool-worker-2] [] - Shut down complete.
[2024-06-02 16:08:10,800] [INFO] [org.apache.flink.runtime.resourcemanager.StandaloneResourceManager] [flink-pekko.actor.default-dispatcher-6] [] - Shut down cluster because application is in CANCELED, diagnostics DispatcherResourceManagerComponent has been closed..
[2024-06-02 16:08:10,800] [INFO] [org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent] [flink-pekko.actor.default-dispatcher-6] [] - Closing components.
[2024-06-02 16:08:10,801] [INFO] [org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcess] [flink-pekko.actor.default-dispatcher-6] [] - Stopping SessionDispatcherLeaderProcess.
[2024-06-02 16:08:10,802] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-7] [] - Stopping dispatcher pekko://flink/user/rpc/dispatcher_2.
[2024-06-02 16:08:10,802] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-7] [] - Stopping all currently running jobs of dispatcher pekko://flink/user/rpc/dispatcher_2.
[2024-06-02 16:08:10,802] [INFO] [org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl] [flink-pekko.actor.default-dispatcher-6] [] - Stopping resource manager service.
[2024-06-02 16:08:10,803] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [flink-pekko.actor.default-dispatcher-7] [] - Stopping credential renewal
[2024-06-02 16:08:10,803] [INFO] [org.apache.flink.runtime.security.token.DefaultDelegationTokenManager] [flink-pekko.actor.default-dispatcher-7] [] - Stopped credential renewal
[2024-06-02 16:08:10,803] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-7] [] - Closing the slot manager.
[2024-06-02 16:08:10,803] [INFO] [org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager] [flink-pekko.actor.default-dispatcher-7] [] - Suspending the slot manager.
[2024-06-02 16:08:10,803] [INFO] [org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl] [pool-2-thread-1] [] - Resource manager service is not running. Ignore revoking leadership.
[2024-06-02 16:08:10,812] [INFO] [org.apache.flink.runtime.io.disk.FileChannelManagerImpl] [flink-pekko.actor.default-dispatcher-8] [] - FileChannelManager removed spill file directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-netty-shuffle-00388425-3bb7-4c98-bec5-c57557565efc
[2024-06-02 16:08:10,812] [INFO] [org.apache.flink.runtime.taskexecutor.KvStateService] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down the kvState service and its components.
[2024-06-02 16:08:10,813] [INFO] [org.apache.flink.runtime.taskexecutor.DefaultJobLeaderService] [flink-pekko.actor.default-dispatcher-8] [] - Stop job leader service.
[2024-06-02 16:08:10,816] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-6] [] - Stopped dispatcher pekko://flink/user/rpc/dispatcher_2.
[2024-06-02 16:08:10,816] [INFO] [org.apache.flink.runtime.filecache.FileCache] [flink-pekko.actor.default-dispatcher-8] [] - removed file cache directory /var/folders/pr/gqmnldt9211cl1k3px25p1gc0000gq/T/flink-dist-cache-308eacf7-5b0a-44fe-8a3e-566d40eccc4c
[2024-06-02 16:08:10,816] [INFO] [org.apache.flink.runtime.taskexecutor.TaskExecutor] [flink-pekko.actor.default-dispatcher-8] [] - Stopped TaskExecutor pekko://flink/user/rpc/taskmanager_0.
[2024-06-02 16:08:10,817] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [RpcService-Supervisor-Termination-Future-Executor-thread-1] [] - Stopping Pekko RPC service.
[2024-06-02 16:08:10,860] [INFO] [org.apache.pekko.actor.CoordinatedShutdown] [flink-metrics-4] [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[2024-06-02 16:08:10,909] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-metrics-4] [] - Stopping Pekko RPC service.
[2024-06-02 16:08:10,909] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-metrics-4] [] - Stopped Pekko RPC service.
[2024-06-02 16:08:10,916] [INFO] [org.apache.pekko.actor.CoordinatedShutdown] [flink-pekko.actor.default-dispatcher-8] [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[2024-06-02 16:08:10,929] [INFO] [org.apache.flink.runtime.blob.PermanentBlobCache] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down BLOB cache
[2024-06-02 16:08:10,930] [INFO] [org.apache.flink.runtime.blob.TransientBlobCache] [flink-pekko.actor.default-dispatcher-8] [] - Shutting down BLOB cache
[2024-06-02 16:08:10,933] [INFO] [org.apache.flink.runtime.blob.BlobServer] [flink-pekko.actor.default-dispatcher-8] [] - Stopped BLOB server at 0.0.0.0:56947
[2024-06-02 16:08:10,936] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-pekko.actor.default-dispatcher-8] [] - Stopped Pekko RPC service.

Process finished with exit code 0

```

</details>

```
Process finished with exit code 0
```


## Run with sbt

The following error occurs when running with sbt.

`Caused by: java.lang.ClassNotFoundException: org.apache.flink.api.common.ExecutionConfig`

<details><summary>full error log</summary>

```
[error] Caused by: java.lang.RuntimeException: org.apache.flink.runtime.client.JobInitializationException: Could not start the JobMaster.
[error]         at org.apache.flink.util.ExceptionUtils.rethrow(ExceptionUtils.java:321)
[error]         at org.apache.flink.util.function.FunctionUtils.lambda$uncheckedFunction$2(FunctionUtils.java:75)
[error]         at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
[error]         at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
[error]         at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
[error]         at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
[error]         at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
[error]         at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
[2024-06-02 15:21:31,922] [INFO] [org.apache.flink.runtime.dispatcher.StandaloneDispatcher] [flink-pekko.actor.default-dispatcher-6] [] - Stopped dispatcher pekko://flink/user/rpc/dispatcher_2.
[error]         at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
[error] Caused by: org.apache.flink.runtime.client.JobInitializationException: Could not start the JobMaster.
[error]         at org.apache.flink.runtime.jobmaster.DefaultJobMasterServiceProcess.lambda$new$0(DefaultJobMasterServiceProcess.java:97)
[error]         at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
[error]         at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
[2024-06-02 15:21:31,922] [INFO] [org.apache.flink.runtime.resourcemanager.ResourceManagerServiceImpl] [pool-30-thread-1] [] - Resource manager service is not running. Ignore revoking leadership.
[error]         at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
[error]         at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1773)
[2024-06-02 15:21:31,924] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [mini-cluster-io-thread-4] [] - Stopping Pekko RPC service.
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[error]         at java.base/java.lang.Thread.run(Thread.java:840)
[error] Caused by: java.util.concurrent.CompletionException: java.lang.RuntimeException: java.lang.ClassNotFoundException: org.apache.flink.api.common.ExecutionConfig
[2024-06-02 15:21:31,948] [INFO] [org.apache.pekko.actor.CoordinatedShutdown] [flink-metrics-5] [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[error]         at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
[2024-06-02 15:21:31,980] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-metrics-5] [] - Stopping Pekko RPC service.
[error]         at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
[2024-06-02 15:21:31,980] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-metrics-5] [] - Stopped Pekko RPC service.
[error]         at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[2024-06-02 15:21:31,984] [INFO] [org.apache.pekko.actor.CoordinatedShutdown] [flink-pekko.actor.default-dispatcher-7] [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[error]         at java.base/java.lang.Thread.run(Thread.java:840)
[error] Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: org.apache.flink.api.common.ExecutionConfig
[error]         at org.apache.flink.util.ExceptionUtils.rethrow(ExceptionUtils.java:321)
[2024-06-02 15:21:31,994] [INFO] [org.apache.flink.runtime.blob.PermanentBlobCache] [flink-pekko.actor.default-dispatcher-6] [] - Shutting down BLOB cache
[error]         at org.apache.flink.util.function.FunctionUtils.lambda$uncheckedSupplier$4(FunctionUtils.java:114)
[2024-06-02 15:21:31,995] [INFO] [org.apache.flink.runtime.blob.TransientBlobCache] [flink-pekko.actor.default-dispatcher-6] [] - Shutting down BLOB cache
[error]         at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[2024-06-02 15:21:31,996] [INFO] [org.apache.flink.runtime.blob.BlobServer] [flink-pekko.actor.default-dispatcher-6] [] - Stopped BLOB server at 0.0.0.0:56296
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[2024-06-02 15:21:31,999] [INFO] [org.apache.flink.runtime.rpc.pekko.PekkoRpcService] [flink-pekko.actor.default-dispatcher-6] [] - Stopped Pekko RPC service.
[error]         at java.base/java.lang.Thread.run(Thread.java:840)
[error] Caused by: java.lang.ClassNotFoundException: org.apache.flink.api.common.ExecutionConfig
[error]         at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
[error]         at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[error]         at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
[error]         at java.base/java.lang.Class.forName0(Native Method)
[error]         at java.base/java.lang.Class.forName(Class.java:467)
[error]         at org.apache.flink.util.InstantiationUtil$ClassLoaderObjectInputStream.resolveClass(InstantiationUtil.java:78)
[error]         at java.base/java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2034)
[error]         at java.base/java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1898)
[error]         at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2224)
[error]         at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
[error]         at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
[error]         at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
[error]         at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:539)
[error]         at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:527)
[error]         at org.apache.flink.util.SerializedValue.deserializeValue(SerializedValue.java:67)
[error]         at org.apache.flink.runtime.scheduler.DefaultSchedulerFactory.createInstance(DefaultSchedulerFactory.java:101)
[error]         at org.apache.flink.runtime.jobmaster.DefaultSlotPoolServiceSchedulerFactory.createScheduler(DefaultSlotPoolServiceSchedulerFactory.java:122)
[error]         at org.apache.flink.runtime.jobmaster.JobMaster.createScheduler(JobMaster.java:379)
[error]         at org.apache.flink.runtime.jobmaster.JobMaster.<init>(JobMaster.java:356)
[error]         at org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory.internalCreateJobMasterService(DefaultJobMasterServiceFactory.java:128)
[error]         at org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory.lambda$createJobMasterService$0(DefaultJobMasterServiceFactory.java:100)
[error]         at org.apache.flink.util.function.FunctionUtils.lambda$uncheckedSupplier$4(FunctionUtils.java:112)
[error]         at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[error]         at java.base/java.lang.Thread.run(Thread.java:840)
[error] stack trace is suppressed; run last Compile / run for the full output
[error] (Compile / run) java.util.concurrent.ExecutionException: java.lang.RuntimeException: org.apache.flink.runtime.client.JobInitializationException: Could not start the JobMaster.

```

</details>



ExecutionConfig is in the flink-core library, but the sbt runtime classpath includes flink-core.

https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java


```
sbt:flink-app> Runtime / fullClasspath
[success] Total time: 0 s, completed 2024/06/02 17:14:54
sbt:flink-app> show Runtime / fullClasspath
[info] * Attributed(/Users/taketo.ikeda/Work/study/flink-app/target/scala-2.12/classes)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.19/scala-library-2.12.19.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime-web/1.18.0/flink-runtime-web-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-scala_2.12/1.18.0/flink-scala_2.12-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-streaming-scala_2.12/1.18.0/flink-streaming-scala_2.12-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-runtime/1.18.0/flink-runtime-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-clients/1.18.0/flink-clients-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-netty/4.1.91.Final-17.0/flink-shaded-netty-4.1.91.Final-17.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-guava/31.1-jre-17.0/flink-shaded-guava-31.1-jre-17.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-jackson/2.14.2-17.0/flink-shaded-jackson-2.14.2-17.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-core/1.18.0/flink-core-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-java/1.18.0/flink-java-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-asm-9/9.5-17.0/flink-shaded-asm-9-9.5-17.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.19/scala-reflect-2.12.19.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.19/scala-compiler-2.12.19.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/twitter/chill_2.12/0.7.6/chill_2.12-0.7.6.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-streaming-java/1.18.0/flink-streaming-java-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-rpc-core/1.18.0/flink-rpc-core-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-rpc-akka-loader/1.18.0/flink-rpc-akka-loader-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-queryable-state-client-java/1.18.0/flink-queryable-state-client-java-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-hadoop-fs/1.18.0/flink-hadoop-fs-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-shaded-zookeeper-3/3.7.1-17.0/flink-shaded-zookeeper-3-3.7.1-17.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-cli/commons-cli/1.5.0/commons-cli-1.5.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/javassist/javassist/3.24.0-GA/javassist-3.24.0-GA.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.10.4/snappy-java-1.1.10.4.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-optimizer/1.18.0/flink-optimizer-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-annotations/1.18.0/flink-annotations-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-metrics-core/1.18.0/flink-metrics-core-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/esotericsoftware/kryo/kryo/2.24.0/kryo-2.24.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/twitter/chill-java/0.7.6/chill-java-0.7.6.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/2.2.0/scala-xml_2.12-2.2.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/flink/flink-file-sink-common/1.18.0/flink-file-sink-common-1.18.0.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/esotericsoftware/minlog/minlog/1.2/minlog-1.2.jar)
[info] * Attributed(/Users/taketo.ikeda/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.1/objenesis-2.1.jar)
[success] Total time: 0 s, completed 2024/06/02 17:14:55


```





